### PR TITLE
Fix Parsing htmx table for monospaced fonts

### DIFF
--- a/changelist.md
+++ b/changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## v0.4.1
+  * Fixed error parsing the hmtx table for monospaced fonts, or any font that ends the hmtx with the optional array of left-side-bearings data. Now only reads the num_h_metrics worth of values as defined in the hhea table.
+
 ## v0.4.0
   * signature of metrics sources is now in binary
   * deprecate the mix tasks.

--- a/lib/truetype_metrics.ex
+++ b/lib/truetype_metrics.ex
@@ -296,7 +296,8 @@ defmodule TruetypeMetrics do
            metrics::binary
          >>,
          num_metrics,
-         out, n
+         out,
+         n
        ) do
     out = Map.put(out, n, advance_width)
     parse_hmtx(metrics, num_metrics - 1, out, n + 1)

--- a/lib/truetype_metrics.ex
+++ b/lib/truetype_metrics.ex
@@ -225,7 +225,7 @@ defmodule TruetypeMetrics do
         Enum.reduce(glyph_ids, %{}, fn {id, codepoints}, out ->
           case hmtx[id] do
             nil -> out
-            {adv, _} -> Enum.reduce(codepoints, out, &Map.put(&2, &1, adv))
+            adv -> Enum.reduce(codepoints, out, &Map.put(&2, &1, adv))
           end
         end)
 
@@ -285,46 +285,21 @@ defmodule TruetypeMetrics do
   defp parse_hhea(_), do: {:error, :invalid_table, "hhea"}
 
   # --------------------------------------------------------
-  defp parse_hmtx(metrics, last_metric, out \\ %{}, n \\ 0)
+  defp parse_hmtx(metrics, num_metrics, out \\ %{}, n \\ 0)
 
-  defp parse_hmtx("", _, out, _), do: {:ok, out}
-
-  defp parse_hmtx(
-         <<advance_width::signed-integer-size(16)-big>>,
-         _,
-         out,
-         _
-       ) do
-    out = Map.put(out, :default, {advance_width, 0})
-    {:ok, out}
-  end
+  defp parse_hmtx(_, 0, out, _), do: {:ok, out}
 
   defp parse_hmtx(
          <<
            advance_width::signed-integer-size(16)-big,
-           lsb::signed-integer-size(16)-big
-         >>,
-         last_metric,
-         out,
-         n
-       )
-       when n == last_metric do
-    out = Map.put(out, :default, {advance_width, lsb})
-    {:ok, out}
-  end
-
-  defp parse_hmtx(
-         <<
-           advance_width::signed-integer-size(16)-big,
-           lsb::signed-integer-size(16)-big,
+           _lsb::signed-integer-size(16)-big,
            metrics::binary
          >>,
-         last_metric,
-         out,
-         n
+         num_metrics,
+         out, n
        ) do
-    out = Map.put(out, n, {advance_width, lsb})
-    parse_hmtx(metrics, last_metric, out, n + 1)
+    out = Map.put(out, n, advance_width)
+    parse_hmtx(metrics, num_metrics - 1, out, n + 1)
   end
 
   # ============================================================================

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule TruetypeMetrics.MixProject do
 
   @app_name :truetype_metrics
 
-  @version "0.4.0"
+  @version "0.4.1"
 
   @elixir_version "~> 1.8"
   @github "https://github.com/boydm/truetype_metrics"


### PR DESCRIPTION
Fixed error parsing the hmtx table for monospaced fonts, or any font that ends the hmtx with the optional array of left-side-bearings data. Now only reads the num_h_metrics worth of values as defined in the hhea table.