### PR TITLE
Cmap 12 extra header data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,7 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 truetype_metrics-*.tar
 
+# don't check in font-awesome. licensing...
+test/fonts/font_awesome/
+
 .DS_Store

--- a/changelist.md
+++ b/changelist.md
@@ -1,5 +1,8 @@
 # Changelist
 
+## v0.6.1
+  * One of the Font Awesome fonts has extra data at the end of the type 12 CMAP table. This update extracts the character groups, then ignores the extra data.
+
 ## v0.6.0
   * Add support and tests for type 12 cmap tables.
 

--- a/lib/truetype_metrics.ex
+++ b/lib/truetype_metrics.ex
@@ -399,19 +399,20 @@ defmodule TruetypeMetrics do
     {:ok, glyph_ids}
   end
 
+
   # type 12 cmap table. Segmented Coverage...
   # https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage
   defp do_parse_unicode_cmap_glyphs(<<
          12::unsigned-integer-size(16)-big,
          0::unsigned-integer-size(16),
-         _size::unsigned-integer-size(32)-big,
-         _language::unsigned-integer-size(32)-big,
+         size::unsigned-integer-size(32)-big,
+         language::unsigned-integer-size(32)-big,
          num_groups::unsigned-integer-size(32)-big,
          map_groups::binary
        >>) do
     # if this is a valid font, the size of each map_group should be 12 bytes (see docs)
-    if byte_size(map_groups) == num_groups * 12 do
-      build_type_12_glyph_ids(map_groups)
+    if byte_size(map_groups) >= num_groups * 12 do
+      build_type_12_glyph_ids(map_groups, num_groups)
     else
       raise """
       invalid type 12 cmap table
@@ -420,9 +421,8 @@ defmodule TruetypeMetrics do
     end
   end
 
-  defp build_type_12_glyph_ids(map_groups, glyph_ids \\ %{})
-  defp build_type_12_glyph_ids(<<>>, glyph_ids), do: {:ok, glyph_ids}
-
+  defp build_type_12_glyph_ids(map_groups, num_groups, glyph_ids \\ %{})
+  defp build_type_12_glyph_ids(_, 0, glyph_ids), do: {:ok, glyph_ids}
   defp build_type_12_glyph_ids(
          <<
            start_char_code::unsigned-integer-size(32)-big,
@@ -430,6 +430,7 @@ defmodule TruetypeMetrics do
            start_glyph_id::unsigned-integer-size(32)-big,
            map_groups::binary
          >>,
+         num_groups,
          glyph_ids
        ) do
     glyph_ids =
@@ -438,7 +439,7 @@ defmodule TruetypeMetrics do
         Map.put(ids, glyph_id, [codepoint | Map.get(ids, glyph_id, [])])
       end)
 
-    build_type_12_glyph_ids(map_groups, glyph_ids)
+    build_type_12_glyph_ids(map_groups, num_groups - 1, glyph_ids)
   end
 
   defp lookup_cmap_type_4(sub_table, skip) do

--- a/lib/truetype_metrics.ex
+++ b/lib/truetype_metrics.ex
@@ -399,14 +399,13 @@ defmodule TruetypeMetrics do
     {:ok, glyph_ids}
   end
 
-
   # type 12 cmap table. Segmented Coverage...
   # https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage
   defp do_parse_unicode_cmap_glyphs(<<
          12::unsigned-integer-size(16)-big,
          0::unsigned-integer-size(16),
-         size::unsigned-integer-size(32)-big,
-         language::unsigned-integer-size(32)-big,
+         _size::unsigned-integer-size(32)-big,
+         _language::unsigned-integer-size(32)-big,
          num_groups::unsigned-integer-size(32)-big,
          map_groups::binary
        >>) do
@@ -423,6 +422,7 @@ defmodule TruetypeMetrics do
 
   defp build_type_12_glyph_ids(map_groups, num_groups, glyph_ids \\ %{})
   defp build_type_12_glyph_ids(_, 0, glyph_ids), do: {:ok, glyph_ids}
+
   defp build_type_12_glyph_ids(
          <<
            start_char_code::unsigned-integer-size(32)-big,

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule TruetypeMetrics.MixProject do
 
   @app_name :truetype_metrics
 
-  @version "0.6.0"
+  @version "0.6.1"
 
   @elixir_version "~> 1.8"
   @github "https://github.com/boydm/truetype_metrics"

--- a/test/truetype_metrics_test.exs
+++ b/test/truetype_metrics_test.exs
@@ -156,4 +156,27 @@ defmodule TruetypeMetricsTest do
     {:ok, %FontMetrics{} = metrics} = TruetypeMetrics.load(@roboto)
     assert metrics.version == FontMetrics.version()
   end
+
+
+  # ============================================================================
+  # font awesome
+  # add font_awesome yourself. When you add the file, the test will run
+  @font_awesome "test/fonts/font_awesome/Font-Awesome-6-Free-Regular-400.ttf"
+  test "loads the Font-Awesome-6-Free-Regular-400.ttf file" do
+    with {:ok, %FontMetrics{} = metrics} <- TruetypeMetrics.load(@font_awesome) do
+      assert metrics.max_box == {-6, -69, 645, 453}
+      assert metrics.units_per_em == 512
+      assert metrics.smallest_ppem == 8
+      assert metrics.direction == 2
+      assert metrics.kerning == %{}
+
+      assert metrics.source.signature_type == @hash_type
+
+      signature = :crypto.hash(@hash_type, File.read!(@font_awesome))
+
+      assert metrics.source.signature == signature
+      assert metrics.source.font_type == :true_type
+    end
+  end
+
 end

--- a/test/truetype_metrics_test.exs
+++ b/test/truetype_metrics_test.exs
@@ -157,7 +157,6 @@ defmodule TruetypeMetricsTest do
     assert metrics.version == FontMetrics.version()
   end
 
-
   # ============================================================================
   # font awesome
   # add font_awesome yourself. When you add the file, the test will run
@@ -178,5 +177,4 @@ defmodule TruetypeMetricsTest do
       assert metrics.source.font_type == :true_type
     end
   end
-
 end


### PR DESCRIPTION
It turns out that some fonts with a type 12 CMAP header, have extra data after the end of the table. I don't know what that data is, and maybe don't care, as it is outside of the spec.

see: https://docs.microsoft.com/en-us/typography/opentype/spec/cmap#format-12-segmented-coverage

Note that if you want to run the test against font-awesome, you should add the font yourself. I'm not sure its license would permit me to include it here, so it can be added later.