### PR TITLE
use standard license name

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule TruetypeMetrics.MixProject do
       name: @app_name,
       contributors: ["Boyd Multerer"],
       maintainers: ["Boyd Multerer"],
-      licenses: ["Apache 2"],
+      licenses: ["Apache-2.0"],
       links: %{Github: @github}
     ]
   end


### PR DESCRIPTION
use the standard name "Apache-2.0"